### PR TITLE
docs(readme): fix typo in installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation
 ------------
 
 ```
-hoodie install appache
+hoodie install appcache
 ```
 
 Usage


### PR DESCRIPTION
(:
