### PR TITLE
Excludes folders from the manifest

### DIFF
--- a/manifest-generator.js
+++ b/manifest-generator.js
@@ -32,8 +32,8 @@ module.exports = function(directory, outFilename) {
 			}
 
 			files.forEach(function(element, index, array) {
-				if (element.indexOf(outFilename) == -1) {
-					if (element == 'index.html') {
+				// exclude files on blacklist; include only files (no directories)
+                		if (element.indexOf(outFilename) == -1 && fs.lstatSync(dir + element).isFile()) {					if (element == 'index.html') {
 						contents.cache.push('/');
 					} else {
 						contents.cache.push('/' + element);

--- a/manifest-generator.js
+++ b/manifest-generator.js
@@ -33,7 +33,8 @@ module.exports = function(directory, outFilename) {
 
 			files.forEach(function(element, index, array) {
 				// exclude files on blacklist; include only files (no directories)
-                		if (element.indexOf(outFilename) == -1 && fs.lstatSync(dir + element).isFile()) {					if (element == 'index.html') {
+				if (element.indexOf(outFilename) == -1 && fs.lstatSync(dir + element).isFile()) {
+					if (element == 'index.html') {
 						contents.cache.push('/');
 					} else {
 						contents.cache.push('/' + element);


### PR DESCRIPTION
This fixes #19 by using the node.js filesystem API to check if an element is a file before adding it to the manifest.
